### PR TITLE
feat(unify-query): cmdb v1beta3 RedisSchemaProvider 动态 Schema 热加载 issue #1193

### DIFF
--- a/pkg/unify-query/cmdb/v1beta3/composite_provider.go
+++ b/pkg/unify-query/cmdb/v1beta3/composite_provider.go
@@ -1,0 +1,255 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+)
+
+// CompositeSchemaProvider 组合 Schema 提供器
+// 支持多个提供器的级联查找，按优先级顺序查询
+// 典型用法：RedisSchemaProvider(高优先级) -> StaticSchemaProvider(兜底)
+type CompositeSchemaProvider struct {
+	providers []SchemaProvider // 按优先级排序，索引越小优先级越高
+	mu        sync.RWMutex
+	ctx       context.Context
+}
+
+// NewCompositeSchemaProvider 创建组合 Schema 提供器
+// providers 参数按优先级顺序传入，索引越小优先级越高
+// 例如: NewCompositeSchemaProvider(redisProvider, staticProvider)
+// 会先查询 redisProvider，如果找不到再查询 staticProvider
+func NewCompositeSchemaProvider(providers ...SchemaProvider) *CompositeSchemaProvider {
+	return &CompositeSchemaProvider{
+		providers: providers,
+		ctx:       context.Background(),
+	}
+}
+
+// AddProvider 添加提供器（追加到最低优先级）
+func (csp *CompositeSchemaProvider) AddProvider(provider SchemaProvider) {
+	csp.mu.Lock()
+	defer csp.mu.Unlock()
+	csp.providers = append(csp.providers, provider)
+}
+
+// GetResourceDefinition 获取资源定义
+// 按优先级顺序查询各个提供器，返回第一个找到的结果
+func (csp *CompositeSchemaProvider) GetResourceDefinition(namespace, name string) (*ResourceDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.get_resource_definition")
+	var err error
+	defer span.End(&err)
+
+	span.Set("resource.namespace", namespace)
+	span.Set("resource.name", name)
+	span.Set("providers.count", len(csp.providers))
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	var lastErr error
+	for i, provider := range csp.providers {
+		rd, providerErr := provider.GetResourceDefinition(namespace, name)
+		if providerErr == nil {
+			span.Set("provider.index", i)
+			return rd, nil
+		}
+		if !errors.Is(providerErr, ErrResourceDefinitionNotFound) {
+			lastErr = providerErr
+		}
+	}
+
+	if lastErr != nil {
+		err = lastErr
+		return nil, err
+	}
+	err = ErrResourceDefinitionNotFound
+	return nil, err
+}
+
+// ListResourceDefinitions 列出资源定义
+// 合并所有提供器的结果，去重（以高优先级为准）
+func (csp *CompositeSchemaProvider) ListResourceDefinitions(namespace string) ([]*ResourceDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.list_resource_definitions")
+	var err error
+	defer span.End(&err)
+
+	span.Set("resource.namespace", namespace)
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	seen := make(map[string]bool) // key: namespace:name
+	result := make([]*ResourceDefinition, 0)
+
+	for _, provider := range csp.providers {
+		list, listErr := provider.ListResourceDefinitions(namespace)
+		if listErr != nil {
+			continue
+		}
+
+		for _, rd := range list {
+			key := makeResourceCacheKey(rd.Namespace, rd.Name)
+			if !seen[key] {
+				seen[key] = true
+				result = append(result, rd)
+			}
+		}
+	}
+
+	span.Set("result.count", len(result))
+	return result, nil
+}
+
+// GetRelationDefinition 获取关联定义
+// 按优先级顺序查询各个提供器，返回第一个找到的结果
+func (csp *CompositeSchemaProvider) GetRelationDefinition(namespace, name string) (*RelationDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.get_relation_definition")
+	var err error
+	defer span.End(&err)
+
+	span.Set("relation.namespace", namespace)
+	span.Set("relation.name", name)
+	span.Set("providers.count", len(csp.providers))
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	var lastErr error
+	for i, provider := range csp.providers {
+		rd, providerErr := provider.GetRelationDefinition(namespace, name)
+		if providerErr == nil {
+			span.Set("provider.index", i)
+			return rd, nil
+		}
+		if !errors.Is(providerErr, ErrRelationDefinitionNotFound) {
+			lastErr = providerErr
+		}
+	}
+
+	if lastErr != nil {
+		err = lastErr
+		return nil, err
+	}
+	err = ErrRelationDefinitionNotFound
+	return nil, err
+}
+
+// ListRelationDefinitions 列出关联定义
+// 合并所有提供器的结果，去重（以高优先级为准）
+func (csp *CompositeSchemaProvider) ListRelationDefinitions(namespace string) ([]*RelationDefinition, error) {
+	_, span := trace.NewSpan(csp.ctx, "composite_provider.list_relation_definitions")
+	var err error
+	defer span.End(&err)
+
+	span.Set("relation.namespace", namespace)
+
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	seen := make(map[string]bool) // key: namespace:name
+	result := make([]*RelationDefinition, 0)
+
+	for _, provider := range csp.providers {
+		list, listErr := provider.ListRelationDefinitions(namespace)
+		if listErr != nil {
+			continue
+		}
+
+		for _, rd := range list {
+			key := makeRelationCacheKey(rd.Namespace, rd.Name)
+			if !seen[key] {
+				seen[key] = true
+				result = append(result, rd)
+			}
+		}
+	}
+
+	span.Set("result.count", len(result))
+	return result, nil
+}
+
+// GetResourcePrimaryKeys 获取资源主键字段列表
+// 按优先级顺序查询各个提供器，返回第一个非空结果
+func (csp *CompositeSchemaProvider) GetResourcePrimaryKeys(resourceType ResourceType) []string {
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	for _, provider := range csp.providers {
+		keys := provider.GetResourcePrimaryKeys(resourceType)
+		if len(keys) > 0 {
+			return keys
+		}
+	}
+
+	return []string{}
+}
+
+// GetRelationSchema 获取关联 Schema
+// 按优先级顺序查询各个提供器，返回第一个找到的结果
+func (csp *CompositeSchemaProvider) GetRelationSchema(relationType RelationType) (*RelationSchema, error) {
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	var lastErr error
+	for _, provider := range csp.providers {
+		schema, err := provider.GetRelationSchema(relationType)
+		if err == nil {
+			return schema, nil
+		}
+		if !errors.Is(err, ErrRelationDefinitionNotFound) {
+			lastErr = err
+		}
+	}
+
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	return nil, ErrRelationDefinitionNotFound
+}
+
+// ListRelationSchemas 列出所有关联 Schema
+// 合并所有提供器的结果，去重（以高优先级为准）
+func (csp *CompositeSchemaProvider) ListRelationSchemas() []RelationSchema {
+	csp.mu.RLock()
+	defer csp.mu.RUnlock()
+
+	seen := make(map[RelationType]bool)
+	result := make([]RelationSchema, 0)
+
+	for _, provider := range csp.providers {
+		schemas := provider.ListRelationSchemas()
+		for _, schema := range schemas {
+			if !seen[schema.RelationType] {
+				seen[schema.RelationType] = true
+				result = append(result, schema)
+			}
+		}
+	}
+
+	return result
+}
+
+// Ensure CompositeSchemaProvider implements SchemaProvider
+var _ SchemaProvider = (*CompositeSchemaProvider)(nil)
+
+// makeResourceCacheKey 生成资源定义去重 key
+func makeResourceCacheKey(namespace, name string) string {
+	return namespace + ":" + name
+}
+
+// makeRelationCacheKey 生成关联定义去重 key
+func makeRelationCacheKey(namespace, name string) string {
+	return namespace + ":" + name
+}

--- a/pkg/unify-query/cmdb/v1beta3/composite_provider_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/composite_provider_test.go
@@ -1,0 +1,301 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCompositeSchemaProvider_Priority 测试优先级查询
+func TestCompositeSchemaProvider_Priority(t *testing.T) {
+	// 创建 StaticSchemaProvider（低优先级）
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider（高优先级）
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	// 在 Redis 中添加一个自定义资源（与静态资源重名）
+	customRd := &ResourceDefinition{
+		Namespace: "",
+		Name:      "pod", // 与 StaticSchemaProvider 中的 pod 重名（注意是小写）
+		Fields: []FieldDefinition{
+			{Name: "custom_field", Required: true}, // 不同的字段
+		},
+		Labels: map[string]string{"source": "redis"},
+	}
+	setResourceDefinitions(t, mr, "", customRd)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider：Redis 优先级高于 Static
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试查询 pod 资源，应该返回 Redis 中的版本
+	t.Run("HighPriorityWins", func(t *testing.T) {
+		rd, err := composite.GetResourceDefinition("", "pod")
+		require.NoError(t, err)
+		assert.Equal(t, "pod", rd.Name)
+		assert.Len(t, rd.Fields, 1)
+		assert.Equal(t, "custom_field", rd.Fields[0].Name)
+		assert.Equal(t, "redis", rd.Labels["source"])
+	})
+
+	// 测试查询只存在于 Static 中的资源
+	t.Run("FallbackToLowPriority", func(t *testing.T) {
+		rd, err := composite.GetResourceDefinition("", "node")
+		require.NoError(t, err)
+		assert.Equal(t, "node", rd.Name)
+	})
+
+	// 测试不存在的资源
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := composite.GetResourceDefinition("", "NonExistent")
+		assert.ErrorIs(t, err, ErrResourceDefinitionNotFound)
+	})
+}
+
+// TestCompositeSchemaProvider_ListMerge 测试列表合并
+func TestCompositeSchemaProvider_ListMerge(t *testing.T) {
+	// 创建 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider 并添加自定义资源
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	customRd1 := &ResourceDefinition{
+		Namespace: "custom",
+		Name:      "app_instance",
+		Fields:    []FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	customRd2 := &ResourceDefinition{
+		Namespace: "custom",
+		Name:      "git_commit",
+		Fields:    []FieldDefinition{{Name: "commit_sha", Required: true}},
+	}
+
+	setResourceDefinitions(t, mr, "custom", customRd1, customRd2)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试列出全局资源（包含 Static 的所有资源）
+	t.Run("ListGlobalResources", func(t *testing.T) {
+		list, err := composite.ListResourceDefinitions("")
+		require.NoError(t, err)
+		assert.Greater(t, len(list), 0) // 应该包含 Static 中的资源
+	})
+
+	// 测试列出自定义命名空间的资源（只来自 Redis）
+	t.Run("ListCustomNamespace", func(t *testing.T) {
+		list, err := composite.ListResourceDefinitions("custom")
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+
+		names := make(map[string]bool)
+		for _, rd := range list {
+			names[rd.Name] = true
+		}
+		assert.True(t, names["app_instance"])
+		assert.True(t, names["git_commit"])
+	})
+}
+
+// TestCompositeSchemaProvider_RelationMerge 测试关联定义合并
+func TestCompositeSchemaProvider_RelationMerge(t *testing.T) {
+	// 创建 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider 并添加自定义关联
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	customRel := &RelationDefinition{
+		Namespace:    "custom",
+		Name:         "app_to_commit",
+		FromResource: "app_instance",
+		ToResource:   "git_commit",
+		Category:     "dynamic",
+		IsBelongsTo:  false,
+	}
+
+	setRelationDefinitions(t, mr, "custom", customRel)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试获取自定义关联
+	t.Run("GetCustomRelation", func(t *testing.T) {
+		rd, err := composite.GetRelationDefinition("custom", "app_to_commit")
+		require.NoError(t, err)
+		assert.Equal(t, "app_to_commit", rd.Name)
+		assert.Equal(t, "dynamic", rd.Category)
+	})
+
+	// 测试获取静态关联
+	t.Run("GetStaticRelation", func(t *testing.T) {
+		list, _ := staticProvider.ListRelationDefinitions("")
+		if len(list) > 0 {
+			firstRelName := list[0].Name
+			rd, err := composite.GetRelationDefinition("", firstRelName)
+			require.NoError(t, err)
+			assert.Equal(t, firstRelName, rd.Name)
+		}
+	})
+
+	// 测试 ListRelationSchemas 合并
+	t.Run("ListRelationSchemas", func(t *testing.T) {
+		schemas := composite.ListRelationSchemas()
+		// 应该包含 Static 的所有 Schema + Redis 的自定义 Schema
+		assert.Greater(t, len(schemas), 0)
+
+		// 验证自定义关联存在
+		found := false
+		for _, schema := range schemas {
+			if schema.RelationType == "custom:app_to_commit" {
+				found = true
+				assert.Equal(t, RelationCategoryDynamic, schema.Category)
+				break
+			}
+		}
+		assert.True(t, found, "custom relation should be in the merged list")
+	})
+}
+
+// TestCompositeSchemaProvider_GetResourcePrimaryKeys 测试主键查询
+func TestCompositeSchemaProvider_GetResourcePrimaryKeys(t *testing.T) {
+	// 创建 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+
+	// 创建 RedisSchemaProvider 并添加自定义资源
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	customRd := &ResourceDefinition{
+		Namespace: "custom",
+		Name:      "app",
+		Fields: []FieldDefinition{
+			{Name: "app_id", Required: true},
+			{Name: "env", Required: true},
+		},
+	}
+
+	setResourceDefinitions(t, mr, "custom", customRd)
+
+	redisProvider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer redisProvider.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(redisProvider, staticProvider)
+
+	// 测试获取自定义资源的主键
+	t.Run("CustomResourcePrimaryKeys", func(t *testing.T) {
+		keys := composite.GetResourcePrimaryKeys("app")
+		assert.Equal(t, []string{"app_id", "env"}, keys)
+	})
+
+	// 测试获取静态资源的主键
+	t.Run("StaticResourcePrimaryKeys", func(t *testing.T) {
+		keys := composite.GetResourcePrimaryKeys("pod")
+		assert.Greater(t, len(keys), 0)
+	})
+
+	// 测试不存在的资源
+	t.Run("NonExistentResource", func(t *testing.T) {
+		keys := composite.GetResourcePrimaryKeys("NonExistent")
+		assert.Empty(t, keys)
+	})
+}
+
+// TestCompositeSchemaProvider_EmptyProviders 测试空提供器列表
+func TestCompositeSchemaProvider_EmptyProviders(t *testing.T) {
+	composite := NewCompositeSchemaProvider()
+
+	t.Run("GetResourceDefinition", func(t *testing.T) {
+		_, err := composite.GetResourceDefinition("", "Pod")
+		assert.ErrorIs(t, err, ErrResourceDefinitionNotFound)
+	})
+
+	t.Run("ListResourceDefinitions", func(t *testing.T) {
+		list, err := composite.ListResourceDefinitions("")
+		require.NoError(t, err)
+		assert.Empty(t, list)
+	})
+
+	t.Run("GetRelationSchema", func(t *testing.T) {
+		_, err := composite.GetRelationSchema("some_relation")
+		assert.ErrorIs(t, err, ErrRelationDefinitionNotFound)
+	})
+
+	t.Run("ListRelationSchemas", func(t *testing.T) {
+		schemas := composite.ListRelationSchemas()
+		assert.Empty(t, schemas)
+	})
+}
+
+// TestCompositeSchemaProvider_AddProvider 测试动态添加提供器
+func TestCompositeSchemaProvider_AddProvider(t *testing.T) {
+	composite := NewCompositeSchemaProvider()
+
+	// 初始状态应该为空
+	_, err := composite.GetResourceDefinition("", "pod")
+	assert.ErrorIs(t, err, ErrResourceDefinitionNotFound)
+
+	// 添加 StaticSchemaProvider
+	staticProvider := NewStaticSchemaProvider()
+	composite.AddProvider(staticProvider)
+
+	// 现在应该能找到资源了
+	rd, err := composite.GetResourceDefinition("", "pod")
+	require.NoError(t, err)
+	assert.Equal(t, "pod", rd.Name)
+}
+
+// TestCompositeSchemaProvider_Deduplication 测试去重逻辑
+func TestCompositeSchemaProvider_Deduplication(t *testing.T) {
+	// 创建两个 StaticSchemaProvider（包含相同的资源）
+	provider1 := NewStaticSchemaProvider()
+	provider2 := NewStaticSchemaProvider()
+
+	// 创建 CompositeSchemaProvider
+	composite := NewCompositeSchemaProvider(provider1, provider2)
+
+	// 列出所有资源
+	list, err := composite.ListResourceDefinitions("")
+	require.NoError(t, err)
+
+	// 检查是否有重复
+	seen := make(map[string]bool)
+	for _, rd := range list {
+		key := makeResourceCacheKey(rd.Namespace, rd.Name)
+		assert.False(t, seen[key], "duplicate resource found: %s", key)
+		seen[key] = true
+	}
+}

--- a/pkg/unify-query/cmdb/v1beta3/redis_provider.go
+++ b/pkg/unify-query/cmdb/v1beta3/redis_provider.go
@@ -1,0 +1,513 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/log"
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/trace"
+	unifyRedis "github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/redis"
+	"github.com/go-redis/redis/v8"
+)
+
+const (
+	// Redis Key 前缀（与 bk-monitor-worker 保持一致）
+	DefaultRedisKeyPrefix = "bkmonitorv3:entity"
+
+	// Pub/Sub 通道后缀
+	DefaultRedisPubSubChannelSuffix = ":channel"
+
+	// 实体 Kind 名称（与 bk-monitor-worker 保持一致）
+	KindResourceDef = "ResourceDefinition"
+	KindRelationDef = "RelationDefinition"
+
+	// Redis Hash key（与 bk-monitor-worker 保持一致）
+	// 结构: bkmonitorv3:entity:{Kind} -> namespace -> {name: JSON, ...}
+	DefaultRedisKeyPrefixResourceDef = DefaultRedisKeyPrefix + ":" + KindResourceDef
+	DefaultRedisKeyPrefixRelationDef = DefaultRedisKeyPrefix + ":" + KindRelationDef
+
+	// Pub/Sub 通道名称
+	DefaultRedisPubSubChannelResourceDef = DefaultRedisKeyPrefixResourceDef + DefaultRedisPubSubChannelSuffix
+	DefaultRedisPubSubChannelRelationDef = DefaultRedisKeyPrefixRelationDef + DefaultRedisPubSubChannelSuffix
+
+	// 内部默认值
+	defaultRedisReconnectInterval = 5 * time.Second
+	defaultRedisReconnectMaxRetry = 10
+)
+
+// RedisSchemaProviderConfig Redis Schema 提供器配置
+type RedisSchemaProviderConfig struct {
+	ReconnectInterval time.Duration
+	ReconnectMaxRetry int
+	ReloadOnStart     bool
+}
+
+// DefaultRedisSchemaProviderConfig 返回默认配置
+func DefaultRedisSchemaProviderConfig() *RedisSchemaProviderConfig {
+	return &RedisSchemaProviderConfig{
+		ReconnectInterval: defaultRedisReconnectInterval,
+		ReconnectMaxRetry: defaultRedisReconnectMaxRetry,
+		ReloadOnStart:     true,
+	}
+}
+
+// RedisSchemaProvider Redis Schema 提供器
+// 从 Redis 动态加载资源和关联定义，支持 Pub/Sub 热更新
+//
+// Redis 数据结构（与 bk-monitor-worker 保持一致）:
+//   - key:   bkmonitorv3:entity:ResourceDefinition
+//   - field: {namespace}
+//   - value: {"name1": {JSON}, "name2": {JSON}, ...}
+type RedisSchemaProvider struct {
+	client redis.UniversalClient
+	config *RedisSchemaProviderConfig
+
+	// 外层 key: namespace, 内层 key: resource/relation name
+	resourceDefinitions map[string]map[string]*ResourceDefinition
+	relationDefinitions map[string]map[string]*RelationDefinition
+	mu                  sync.RWMutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// RedisSchemaProviderOption Redis Schema 提供器配置选项
+type RedisSchemaProviderOption func(*RedisSchemaProviderConfig)
+
+// WithReloadOnStart 设置启动时是否重新加载所有数据
+func WithReloadOnStart(reload bool) RedisSchemaProviderOption {
+	return func(config *RedisSchemaProviderConfig) {
+		config.ReloadOnStart = reload
+	}
+}
+
+// WithReconnectConfig 设置重连配置
+func WithReconnectConfig(interval time.Duration, maxRetry int) RedisSchemaProviderOption {
+	return func(config *RedisSchemaProviderConfig) {
+		config.ReconnectInterval = interval
+		config.ReconnectMaxRetry = maxRetry
+	}
+}
+
+// NewRedisSchemaProvider 创建 Redis Schema 提供器（使用自定义客户端）
+func NewRedisSchemaProvider(client redis.UniversalClient, opts ...RedisSchemaProviderOption) (*RedisSchemaProvider, error) {
+	config := DefaultRedisSchemaProviderConfig()
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	provider := &RedisSchemaProvider{
+		client:              client,
+		config:              config,
+		resourceDefinitions: make(map[string]map[string]*ResourceDefinition),
+		relationDefinitions: make(map[string]map[string]*RelationDefinition),
+		ctx:                 ctx,
+		cancel:              cancel,
+	}
+
+	if config.ReloadOnStart {
+		if err := provider.loadAllEntities(); err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to load entities: %w", err)
+		}
+	}
+
+	provider.wg.Add(1)
+	go provider.subscribeEntities()
+
+	return provider, nil
+}
+
+// NewRedisSchemaProviderWithGlobalClient 创建 Redis Schema 提供器（使用全局客户端）
+func NewRedisSchemaProviderWithGlobalClient(opts ...RedisSchemaProviderOption) (*RedisSchemaProvider, error) {
+	client := unifyRedis.Client()
+	if client == nil {
+		return nil, fmt.Errorf("global redis client is not initialized, please call redis.SetInstance first")
+	}
+	return NewRedisSchemaProvider(client, opts...)
+}
+
+// Close 关闭提供器
+func (rsp *RedisSchemaProvider) Close() error {
+	rsp.cancel()
+	rsp.wg.Wait()
+	return nil
+}
+
+// loadAllEntities 启动时全量加载所有实体
+func (rsp *RedisSchemaProvider) loadAllEntities() error {
+	var err error
+	ctx, span := trace.NewSpan(rsp.ctx, "redis_provider.load_all_entities")
+	defer span.End(&err)
+
+	if err = rsp.loadEntitiesByKind(ctx, KindResourceDef); err != nil {
+		return fmt.Errorf("failed to load resource definitions: %w", err)
+	}
+	if err = rsp.loadEntitiesByKind(ctx, KindRelationDef); err != nil {
+		return fmt.Errorf("failed to load relation definitions: %w", err)
+	}
+
+	resourceCount := 0
+	for _, nsMap := range rsp.resourceDefinitions {
+		resourceCount += len(nsMap)
+	}
+	relationCount := 0
+	for _, nsMap := range rsp.relationDefinitions {
+		relationCount += len(nsMap)
+	}
+
+	log.Infof(ctx, "loaded %d resource definitions, %d relation definitions", resourceCount, relationCount)
+	return nil
+}
+
+// loadEntitiesByKind 按 Kind 全量加载实体
+// Redis 结构: {prefix}:{kind} -> namespace -> {name: JSON, ...}
+func (rsp *RedisSchemaProvider) loadEntitiesByKind(ctx context.Context, kind string) error {
+	redisKey := DefaultRedisKeyPrefix + ":" + kind
+
+	result, err := rsp.client.HGetAll(ctx, redisKey).Result()
+	if err != nil {
+		return fmt.Errorf("failed to hgetall %s: %w", redisKey, err)
+	}
+
+	for namespace, entitiesJSON := range result {
+		var entities map[string]json.RawMessage
+		if unmarshalErr := json.Unmarshal([]byte(entitiesJSON), &entities); unmarshalErr != nil {
+			log.Warnf(ctx, "failed to unmarshal entities for namespace %s: %v", namespace, unmarshalErr)
+			continue
+		}
+		for name, jsonData := range entities {
+			if loadErr := rsp.loadEntityByKind(kind, namespace, name, string(jsonData)); loadErr != nil {
+				log.Warnf(ctx, "failed to load %s %s:%s: %v", kind, namespace, name, loadErr)
+			}
+		}
+	}
+	return nil
+}
+
+// loadEntityByKind 加载单个实体到缓存
+func (rsp *RedisSchemaProvider) loadEntityByKind(kind, namespace, name, jsonData string) error {
+	switch kind {
+	case KindResourceDef:
+		var def ResourceDefinition
+		if err := json.Unmarshal([]byte(jsonData), &def); err != nil {
+			return fmt.Errorf("failed to unmarshal ResourceDefinition: %w", err)
+		}
+		rsp.mu.Lock()
+		if _, ok := rsp.resourceDefinitions[namespace]; !ok {
+			rsp.resourceDefinitions[namespace] = make(map[string]*ResourceDefinition)
+		}
+		rsp.resourceDefinitions[namespace][name] = &def
+		rsp.mu.Unlock()
+
+	case KindRelationDef:
+		var def RelationDefinition
+		if err := json.Unmarshal([]byte(jsonData), &def); err != nil {
+			return fmt.Errorf("failed to unmarshal RelationDefinition: %w", err)
+		}
+		rsp.mu.Lock()
+		if _, ok := rsp.relationDefinitions[namespace]; !ok {
+			rsp.relationDefinitions[namespace] = make(map[string]*RelationDefinition)
+		}
+		rsp.relationDefinitions[namespace][name] = &def
+		rsp.mu.Unlock()
+	}
+	return nil
+}
+
+// reloadNamespace 按 namespace 全量重建该 kind 的本地缓存（与 bk-monitor-worker 保持一致）
+func (rsp *RedisSchemaProvider) reloadNamespace(ctx context.Context, kind, namespace string) error {
+	redisKey := DefaultRedisKeyPrefix + ":" + kind
+
+	entitiesJSON, err := rsp.client.HGet(ctx, redisKey, namespace).Result()
+	if errors.Is(err, redis.Nil) {
+		// namespace 已不存在，清空缓存
+		rsp.mu.Lock()
+		switch kind {
+		case KindResourceDef:
+			delete(rsp.resourceDefinitions, namespace)
+		case KindRelationDef:
+			delete(rsp.relationDefinitions, namespace)
+		}
+		rsp.mu.Unlock()
+		log.Infof(ctx, "cleared namespace cache: kind=%s, ns=%s", kind, namespace)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to hget: %w", err)
+	}
+
+	var entities map[string]json.RawMessage
+	if err = json.Unmarshal([]byte(entitiesJSON), &entities); err != nil {
+		return fmt.Errorf("failed to unmarshal entities: %w", err)
+	}
+
+	switch kind {
+	case KindResourceDef:
+		newMap := make(map[string]*ResourceDefinition, len(entities))
+		for name, jsonData := range entities {
+			var def ResourceDefinition
+			if unmarshalErr := json.Unmarshal(jsonData, &def); unmarshalErr != nil {
+				log.Warnf(ctx, "failed to unmarshal ResourceDefinition %s:%s: %v", namespace, name, unmarshalErr)
+				continue
+			}
+			newMap[name] = &def
+		}
+		rsp.mu.Lock()
+		rsp.resourceDefinitions[namespace] = newMap
+		rsp.mu.Unlock()
+
+	case KindRelationDef:
+		newMap := make(map[string]*RelationDefinition, len(entities))
+		for name, jsonData := range entities {
+			var def RelationDefinition
+			if unmarshalErr := json.Unmarshal(jsonData, &def); unmarshalErr != nil {
+				log.Warnf(ctx, "failed to unmarshal RelationDefinition %s:%s: %v", namespace, name, unmarshalErr)
+				continue
+			}
+			newMap[name] = &def
+		}
+		rsp.mu.Lock()
+		rsp.relationDefinitions[namespace] = newMap
+		rsp.mu.Unlock()
+	}
+
+	log.Infof(ctx, "reloaded namespace cache: kind=%s, ns=%s, count=%d", kind, namespace, len(entities))
+	return nil
+}
+
+// MsgPayload Pub/Sub 消息体（与 bk-monitor-worker 保持一致）
+type MsgPayload struct {
+	Namespace string `json:"namespace"`
+	Kind      string `json:"kind"`
+}
+
+// subscribeEntities 订阅实体变更通知
+func (rsp *RedisSchemaProvider) subscribeEntities() {
+	defer rsp.wg.Done()
+
+	channels := []string{
+		DefaultRedisPubSubChannelResourceDef,
+		DefaultRedisPubSubChannelRelationDef,
+	}
+
+	retryCount := 0
+	for {
+		select {
+		case <-rsp.ctx.Done():
+			return
+		default:
+		}
+
+		pubsub := rsp.client.Subscribe(rsp.ctx, channels...)
+		log.Infof(rsp.ctx, "subscribed to entity channels: %v", channels)
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			ch := pubsub.Channel()
+			for {
+				select {
+				case <-rsp.ctx.Done():
+					return
+				case msg := <-ch:
+					if msg == nil {
+						return
+					}
+
+					var payload MsgPayload
+					if err := json.Unmarshal([]byte(msg.Payload), &payload); err != nil {
+						log.Warnf(rsp.ctx, "invalid pubsub payload: %s, err: %v", msg.Payload, err)
+						continue
+					}
+					if payload.Namespace == "" || payload.Kind == "" {
+						log.Warnf(rsp.ctx, "empty namespace or kind in payload: %s", msg.Payload)
+						continue
+					}
+
+					log.Infof(rsp.ctx, "received entity update: kind=%s namespace=%s", payload.Kind, payload.Namespace)
+					if err := rsp.reloadNamespace(rsp.ctx, payload.Kind, payload.Namespace); err != nil {
+						log.Errorf(rsp.ctx, "failed to reload namespace %s:%s: %v", payload.Kind, payload.Namespace, err)
+					}
+				}
+			}
+		}()
+
+		select {
+		case <-rsp.ctx.Done():
+			pubsub.Close()
+			<-done
+			return
+		case <-done:
+			pubsub.Close()
+		}
+
+		retryCount++
+		if retryCount > rsp.config.ReconnectMaxRetry {
+			log.Errorf(rsp.ctx, "max retry count reached for entity subscription")
+			return
+		}
+
+		log.Warnf(rsp.ctx, "entity subscription disconnected, retrying in %v (attempt %d/%d)",
+			rsp.config.ReconnectInterval, retryCount, rsp.config.ReconnectMaxRetry)
+
+		select {
+		case <-rsp.ctx.Done():
+			return
+		case <-time.After(rsp.config.ReconnectInterval):
+		}
+	}
+}
+
+// GetResourceDefinition 获取资源定义
+func (rsp *RedisSchemaProvider) GetResourceDefinition(namespace, name string) (*ResourceDefinition, error) {
+	var err error
+	ctx, span := trace.NewSpan(rsp.ctx, "redis_provider.get_resource_definition")
+	defer span.End(&err)
+
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	if nsMap, ok := rsp.resourceDefinitions[namespace]; ok {
+		if def, ok := nsMap[name]; ok {
+			span.Set("cache.hit", true)
+			return def, nil
+		}
+	}
+
+	err = ErrResourceDefinitionNotFound
+	span.Set("cache.hit", false)
+	log.Debugf(ctx, "resource definition not found: namespace=%s, name=%s", namespace, name)
+	return nil, err
+}
+
+// ListResourceDefinitions 列出指定命名空间下的所有资源定义
+func (rsp *RedisSchemaProvider) ListResourceDefinitions(namespace string) ([]*ResourceDefinition, error) {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	result := make([]*ResourceDefinition, 0)
+	if namespace == "" {
+		for _, nsMap := range rsp.resourceDefinitions {
+			for _, def := range nsMap {
+				result = append(result, def)
+			}
+		}
+		return result, nil
+	}
+
+	if nsMap, ok := rsp.resourceDefinitions[namespace]; ok {
+		for _, def := range nsMap {
+			result = append(result, def)
+		}
+	}
+	return result, nil
+}
+
+// GetRelationDefinition 获取关联定义
+func (rsp *RedisSchemaProvider) GetRelationDefinition(namespace, name string) (*RelationDefinition, error) {
+	var err error
+	ctx, span := trace.NewSpan(rsp.ctx, "redis_provider.get_relation_definition")
+	defer span.End(&err)
+
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	if nsMap, ok := rsp.relationDefinitions[namespace]; ok {
+		if def, ok := nsMap[name]; ok {
+			span.Set("cache.hit", true)
+			return def, nil
+		}
+	}
+
+	err = ErrRelationDefinitionNotFound
+	span.Set("cache.hit", false)
+	log.Debugf(ctx, "relation definition not found: namespace=%s, name=%s", namespace, name)
+	return nil, err
+}
+
+// ListRelationDefinitions 列出指定命名空间下的所有关联定义
+func (rsp *RedisSchemaProvider) ListRelationDefinitions(namespace string) ([]*RelationDefinition, error) {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	result := make([]*RelationDefinition, 0)
+	if namespace == "" {
+		for _, nsMap := range rsp.relationDefinitions {
+			for _, def := range nsMap {
+				result = append(result, def)
+			}
+		}
+		return result, nil
+	}
+
+	if nsMap, ok := rsp.relationDefinitions[namespace]; ok {
+		for _, def := range nsMap {
+			result = append(result, def)
+		}
+	}
+	return result, nil
+}
+
+// GetResourcePrimaryKeys 获取资源类型的主键字段列表
+func (rsp *RedisSchemaProvider) GetResourcePrimaryKeys(resourceType ResourceType) []string {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	for _, nsMap := range rsp.resourceDefinitions {
+		for _, rd := range nsMap {
+			if rd.ToResourceType() == resourceType {
+				return rd.GetPrimaryKeys()
+			}
+		}
+	}
+	return []string{}
+}
+
+// GetRelationSchema 获取关联关系的 Schema
+func (rsp *RedisSchemaProvider) GetRelationSchema(relationType RelationType) (*RelationSchema, error) {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	for _, nsMap := range rsp.relationDefinitions {
+		for _, rd := range nsMap {
+			if rd.ToRelationType() == relationType {
+				schema := rd.ToRelationSchema()
+				return &schema, nil
+			}
+		}
+	}
+	return nil, ErrRelationDefinitionNotFound
+}
+
+// ListRelationSchemas 列出所有关联 Schema
+func (rsp *RedisSchemaProvider) ListRelationSchemas() []RelationSchema {
+	rsp.mu.RLock()
+	defer rsp.mu.RUnlock()
+
+	result := make([]RelationSchema, 0)
+	for _, nsMap := range rsp.relationDefinitions {
+		for _, rd := range nsMap {
+			result = append(result, rd.ToRelationSchema())
+		}
+	}
+	return result
+}
+
+// Ensure RedisSchemaProvider implements SchemaProvider
+var _ SchemaProvider = (*RedisSchemaProvider)(nil)

--- a/pkg/unify-query/cmdb/v1beta3/redis_provider_test.go
+++ b/pkg/unify-query/cmdb/v1beta3/redis_provider_test.go
@@ -1,0 +1,361 @@
+// Tencent is pleased to support the open source community by making
+// 蓝鲸智云 - 监控平台 (BlueKing - Monitor) available.
+// Copyright (C) 2022 THL A29 Limited, a Tencent company. All rights reserved.
+// Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://opensource.org/licenses/MIT
+// Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+// an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package v1beta3
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setupTestRedis 创建测试用的 Redis 实例
+func setupTestRedis(t *testing.T) (*redis.Client, *miniredis.Miniredis) {
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{
+		Addr: mr.Addr(),
+	})
+	return client, mr
+}
+
+// setResourceDefinitions 向 miniredis 写入资源定义
+// Redis 结构: bkmonitorv3:entity:ResourceDefinition -> namespace -> {name: JSON, ...}
+func setResourceDefinitions(t *testing.T, mr *miniredis.Miniredis, namespace string, defs ...*ResourceDefinition) {
+	t.Helper()
+	entities := make(map[string]json.RawMessage, len(defs))
+	for _, def := range defs {
+		b, err := json.Marshal(def)
+		require.NoError(t, err)
+		entities[def.Name] = b
+	}
+	b, err := json.Marshal(entities)
+	require.NoError(t, err)
+	mr.HSet(DefaultRedisKeyPrefixResourceDef, namespace, string(b))
+}
+
+// setRelationDefinitions 向 miniredis 写入关联定义
+// Redis 结构: bkmonitorv3:entity:RelationDefinition -> namespace -> {name: JSON, ...}
+func setRelationDefinitions(t *testing.T, mr *miniredis.Miniredis, namespace string, defs ...*RelationDefinition) {
+	t.Helper()
+	entities := make(map[string]json.RawMessage, len(defs))
+	for _, def := range defs {
+		b, err := json.Marshal(def)
+		require.NoError(t, err)
+		entities[def.Name] = b
+	}
+	b, err := json.Marshal(entities)
+	require.NoError(t, err)
+	mr.HSet(DefaultRedisKeyPrefixRelationDef, namespace, string(b))
+}
+
+// TestRedisSchemaProvider_LoadResourceDefinitions 测试加载资源定义
+func TestRedisSchemaProvider_LoadResourceDefinitions(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd1 := &ResourceDefinition{
+		Namespace: "test",
+		Name:      "app_instance",
+		Fields: []FieldDefinition{
+			{Name: "app_id", Required: true},
+			{Name: "instance_id", Required: true},
+			{Name: "version", Required: false},
+		},
+		Labels: map[string]string{"env": "test"},
+	}
+	rd2 := &ResourceDefinition{
+		Namespace: "test",
+		Name:      "git_commit",
+		Fields: []FieldDefinition{
+			{Name: "repo", Required: true},
+			{Name: "commit_sha", Required: true},
+		},
+	}
+	setResourceDefinitions(t, mr, "test", rd1, rd2)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	t.Run("GetResourceDefinition", func(t *testing.T) {
+		rd, err := provider.GetResourceDefinition("test", "app_instance")
+		require.NoError(t, err)
+		assert.Equal(t, "test", rd.Namespace)
+		assert.Equal(t, "app_instance", rd.Name)
+		assert.Len(t, rd.Fields, 3)
+		assert.Equal(t, []string{"app_id", "instance_id"}, rd.GetPrimaryKeys())
+	})
+
+	t.Run("ListResourceDefinitions", func(t *testing.T) {
+		list, err := provider.ListResourceDefinitions("test")
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+	})
+
+	t.Run("GetResourcePrimaryKeys", func(t *testing.T) {
+		keys := provider.GetResourcePrimaryKeys("app_instance")
+		assert.Equal(t, []string{"app_id", "instance_id"}, keys)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := provider.GetResourceDefinition("test", "nonexistent")
+		assert.ErrorIs(t, err, ErrResourceDefinitionNotFound)
+	})
+}
+
+// TestRedisSchemaProvider_LoadRelationDefinitions 测试加载关联定义
+func TestRedisSchemaProvider_LoadRelationDefinitions(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd1 := &RelationDefinition{
+		Namespace:    "test",
+		Name:         "app_to_commit",
+		FromResource: "app_instance",
+		ToResource:   "git_commit",
+		Category:     "dynamic",
+	}
+	rd2 := &RelationDefinition{
+		Namespace:    "test",
+		Name:         "commit_to_author",
+		FromResource: "git_commit",
+		ToResource:   "developer",
+		Category:     "static",
+		IsBelongsTo:  true,
+	}
+	setRelationDefinitions(t, mr, "test", rd1, rd2)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	t.Run("GetRelationDefinition", func(t *testing.T) {
+		rd, err := provider.GetRelationDefinition("test", "app_to_commit")
+		require.NoError(t, err)
+		assert.Equal(t, "test", rd.Namespace)
+		assert.Equal(t, "app_to_commit", rd.Name)
+		assert.Equal(t, "app_instance", rd.FromResource)
+		assert.Equal(t, "git_commit", rd.ToResource)
+		assert.Equal(t, "dynamic", rd.Category)
+	})
+
+	t.Run("ListRelationDefinitions", func(t *testing.T) {
+		list, err := provider.ListRelationDefinitions("test")
+		require.NoError(t, err)
+		assert.Len(t, list, 2)
+	})
+
+	t.Run("GetRelationSchema", func(t *testing.T) {
+		schema, err := provider.GetRelationSchema("test:app_to_commit")
+		require.NoError(t, err)
+		assert.Equal(t, RelationType("test:app_to_commit"), schema.RelationType)
+		assert.Equal(t, RelationCategoryDynamic, schema.Category)
+		assert.Equal(t, ResourceType("app_instance"), schema.FromType)
+		assert.Equal(t, ResourceType("git_commit"), schema.ToType)
+		assert.False(t, schema.IsBelongsTo)
+	})
+
+	t.Run("ListRelationSchemas", func(t *testing.T) {
+		schemas := provider.ListRelationSchemas()
+		assert.Len(t, schemas, 2)
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		_, err := provider.GetRelationDefinition("test", "nonexistent")
+		assert.ErrorIs(t, err, ErrRelationDefinitionNotFound)
+	})
+}
+
+// TestRedisSchemaProvider_HotReload 测试热更新（Pub/Sub）
+func TestRedisSchemaProvider_HotReload(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 验证初始数据
+	result, err := provider.GetResourceDefinition("test", "app")
+	require.NoError(t, err)
+	assert.Len(t, result.Fields, 1)
+
+	// 等待 Pub/Sub 订阅建立
+	time.Sleep(100 * time.Millisecond)
+
+	// 更新 Redis 数据
+	rd.Fields = append(rd.Fields, FieldDefinition{Name: "version", Required: false})
+	setResourceDefinitions(t, mr, "test", rd)
+
+	// 发送 Pub/Sub 通知（JSON 格式，与 bk-monitor-worker 保持一致）
+	ctx := context.Background()
+	payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+	client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+
+	// 等待热更新完成（轮询，最多 1 秒）
+	var updated *ResourceDefinition
+	for i := 0; i < 20; i++ {
+		updated, err = provider.GetResourceDefinition("test", "app")
+		if err == nil && len(updated.Fields) == 2 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.NoError(t, err)
+	require.Len(t, updated.Fields, 2)
+	assert.Equal(t, "version", updated.Fields[1].Name)
+}
+
+// TestRedisSchemaProvider_HotDelete 测试热删除（namespace 不存在时清空缓存）
+func TestRedisSchemaProvider_HotDelete(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 验证初始数据
+	_, err = provider.GetResourceDefinition("test", "app")
+	require.NoError(t, err)
+
+	// 等待 Pub/Sub 订阅建立
+	time.Sleep(100 * time.Millisecond)
+
+	// 删除 Redis Hash field（整个 namespace）
+	mr.HDel(DefaultRedisKeyPrefixResourceDef, "test")
+
+	// 发送 Pub/Sub 通知
+	ctx := context.Background()
+	payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+	client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+
+	// 等待删除完成
+	for i := 0; i < 20; i++ {
+		_, err = provider.GetResourceDefinition("test", "app")
+		if err != nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	assert.ErrorIs(t, err, ErrResourceDefinitionNotFound)
+}
+
+// TestRedisSchemaProvider_WithoutReloadOnStart 测试不预加载
+func TestRedisSchemaProvider_WithoutReloadOnStart(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	// 创建提供器，不预加载
+	provider, err := NewRedisSchemaProvider(client, WithReloadOnStart(false))
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 等待 Pub/Sub 订阅建立
+	time.Sleep(100 * time.Millisecond)
+
+	// 立即查询，应该找不到（因为没有预加载）
+	_, err = provider.GetResourceDefinition("test", "app")
+	assert.ErrorIs(t, err, ErrResourceDefinitionNotFound)
+
+	// 发送 Pub/Sub 通知触发加载
+	ctx := context.Background()
+	payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+	client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+
+	// 等待加载完成
+	var result *ResourceDefinition
+	for i := 0; i < 20; i++ {
+		result, err = provider.GetResourceDefinition("test", "app")
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	require.NoError(t, err)
+	assert.Equal(t, "app", result.Name)
+}
+
+// TestRedisSchemaProvider_ConcurrentAccess 测试并发访问
+func TestRedisSchemaProvider_ConcurrentAccess(t *testing.T) {
+	client, mr := setupTestRedis(t)
+	defer mr.Close()
+
+	rd := &ResourceDefinition{
+		Namespace: "test",
+		Name:      "app",
+		Fields:    []FieldDefinition{{Name: "app_id", Required: true}},
+	}
+	setResourceDefinitions(t, mr, "test", rd)
+
+	provider, err := NewRedisSchemaProvider(client)
+	require.NoError(t, err)
+	defer provider.Close()
+
+	// 并发读写测试
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				_, _ = provider.GetResourceDefinition("test", "app")
+				_ = provider.ListRelationSchemas()
+			}
+			done <- true
+		}()
+	}
+
+	// 同时进行更新
+	go func() {
+		ctx := context.Background()
+		payload, _ := json.Marshal(MsgPayload{Namespace: "test", Kind: KindResourceDef})
+		for i := 0; i < 50; i++ {
+			client.Publish(ctx, DefaultRedisPubSubChannelResourceDef, string(payload))
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// 验证数据一致性
+	result, err := provider.GetResourceDefinition("test", "app")
+	require.NoError(t, err)
+	assert.Equal(t, "app", result.Name)
+}

--- a/pkg/unify-query/redis/redis.go
+++ b/pkg/unify-query/redis/redis.go
@@ -134,3 +134,20 @@ var Subscribe = func(ctx context.Context, channels ...string) <-chan *goRedis.Me
 	p := globalInstance.client.Subscribe(ctx, channels...)
 	return p.Channel()
 }
+
+// Scan 迭代式扫描 key，避免阻塞 Redis
+// cursor: 游标位置，首次调用传 0
+// match: 匹配模式
+// count: 建议返回的 key 数量（实际可能更多或更少）
+var Scan = func(ctx context.Context, cursor uint64, match string, count int64) (keys []string, nextCursor uint64, err error) {
+	log.Debugf(ctx, "[redis] scan cursor=%d match=%s count=%d", cursor, match, count)
+	res := globalInstance.client.Scan(ctx, cursor, match, count)
+	return res.Result()
+}
+
+// Publish 发布消息到指定通道
+var Publish = func(ctx context.Context, channel string, message interface{}) (int64, error) {
+	log.Debugf(ctx, "[redis] publish %s", channel)
+	res := globalInstance.client.Publish(ctx, channel, message)
+	return res.Result()
+}


### PR DESCRIPTION
## Summary

- 新增 `RedisSchemaProvider`，从 Redis 动态加载 ResourceDefinition / RelationDefinition，支持 Pub/Sub 热更新
- Redis 数据格式与 bk-monitor PR #9623 / bmw PR #1199 三方保持一致：
  `bkmonitorv3:entity:{Kind}` → field: `namespace` → value: `{name: JSON, ...}`
- Pub/Sub 消息格式：`{"namespace":"...", "kind":"..."}` JSON，按 namespace 全量热重建缓存
- 新增 `CompositeSchemaProvider`，支持多 provider 优先级合并（Redis 优先于 Static）
- `redis/redis.go`：暴露全局 UniversalClient

## 与 bmw PR #1199 的关系

两者逻辑相似但**不重复**：bmw 是写入端，unify-query 是读取端，各自独立实现。

## 拆分说明

本 PR 是 #1193 的拆分子 PR（**PR B**），依赖 PR A（TencentBlueKing/bkmonitor-datalink#1228）。

完整拆分计划见 TencentBlueKing/bkmonitor-datalink#1193 comment。

**合入顺序**：#1227（PR C）→ #1228（PR A）→ 本 PR

## Test plan

- [ ] `go test ./cmdb/v1beta3/...` 通过（含 RedisSchemaProvider / CompositeSchemaProvider 测试）

🤖 Generated with [Claude Code](https://claude.com/claude-code)