### PR TITLE
fix: handle avg merge across routes

### DIFF
--- a/pkg/unify-query/internal/function/merge_series.go
+++ b/pkg/unify-query/internal/function/merge_series.go
@@ -48,6 +48,10 @@ func NewMergeSeriesSetWithFuncAndSort(name string) func(...storage.Series) stora
 				}
 				return b
 			}
+		case Avg, AvgOT, Mean:
+			aggFunc = func(a, b float64) float64 {
+				return a + b
+			}
 		default: // 默认使用sum
 			aggFunc = func(a, b float64) float64 {
 				return a + b
@@ -56,6 +60,7 @@ func NewMergeSeriesSetWithFuncAndSort(name string) func(...storage.Series) stora
 
 		// 按时间戳合并值
 		valueMap := make(map[int64]float64)
+		countMap := make(map[int64]float64)
 		for _, s := range series {
 			it := s.Iterator(nil)
 			for it.Next() == chunkenc.ValFloat {
@@ -65,6 +70,7 @@ func NewMergeSeriesSetWithFuncAndSort(name string) func(...storage.Series) stora
 				} else {
 					valueMap[t] = v
 				}
+				countMap[t]++
 			}
 			if err := it.Err(); err != nil {
 				return &storage.SeriesEntry{
@@ -80,6 +86,11 @@ func NewMergeSeriesSetWithFuncAndSort(name string) func(...storage.Series) stora
 
 		sortedData := make([]prompb.Sample, 0, len(valueMap))
 		for t, v := range valueMap {
+			if isAvgFunc(name) {
+				if count := countMap[t]; count > 0 {
+					v = v / count
+				}
+			}
 			sortedData = append(sortedData, prompb.Sample{Timestamp: t, Value: v})
 		}
 		sort.Slice(sortedData, func(i, j int) bool {

--- a/pkg/unify-query/internal/function/merge_series_test.go
+++ b/pkg/unify-query/internal/function/merge_series_test.go
@@ -349,7 +349,7 @@ func TestMergeSeriesSet(t *testing.T) {
 					},
 				},
 			},
-			fn: function.NewMergeSeriesSetWithFuncAndSort("max"),
+			fn: function.NewMergeSeriesSetWithFuncAndSort(function.Max),
 		},
 		"two queryResult with mergeSeriesSetWithFuncAndSort min": {
 			qrs: []*prompb.QueryResult{
@@ -415,6 +415,71 @@ func TestMergeSeriesSet(t *testing.T) {
 				},
 			},
 			fn: function.NewMergeSeriesSetWithFuncAndSort("min"),
+		},
+		"two queryResult with mergeSeriesSetWithFuncAndSort avg": {
+			qrs: []*prompb.QueryResult{
+				{
+					Timeseries: []*prompb.TimeSeries{
+						ts1, ts2,
+					},
+				},
+				{
+					Timeseries: []*prompb.TimeSeries{
+						ts3, ts4,
+					},
+				},
+			},
+			ts: mock.TimeSeriesList{
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "up",
+						},
+						{
+							Name:  "job",
+							Value: "elasticsearch",
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Value:     5,
+							Timestamp: 60,
+						},
+						{
+							Value:     6,
+							Timestamp: 120,
+						},
+					},
+				},
+				{
+					Labels: []prompb.Label{
+						{
+							Name:  "__name__",
+							Value: "up",
+						},
+						{
+							Name:  "job",
+							Value: "prometheus",
+						},
+					},
+					Samples: []prompb.Sample{
+						{
+							Value:     2.5,
+							Timestamp: 0,
+						},
+						{
+							Value:     5,
+							Timestamp: 60,
+						},
+						{
+							Value:     3,
+							Timestamp: 120,
+						},
+					},
+				},
+			},
+			fn: function.NewMergeSeriesSetWithFuncAndSort(function.Avg),
 		},
 	}
 

--- a/pkg/unify-query/internal/function/samples.go
+++ b/pkg/unify-query/internal/function/samples.go
@@ -22,6 +22,7 @@ const (
 	Min   = "min"
 	Max   = "max"
 	Avg   = "avg"
+	Mean  = "mean"
 	Sum   = "sum"
 	Count = "count"
 
@@ -32,11 +33,22 @@ const (
 	CountOT = "count_over_time"
 )
 
+func isAvgFunc(name string) bool {
+	switch strings.ToLower(name) {
+	case Avg, AvgOT, Mean:
+		return true
+	default:
+		return false
+	}
+}
+
 // MergeSamplesWithFuncAndSort 合并 samples 数据，如果相同时间的进行函数处理，并且按照时间排序
 func MergeSamplesWithFuncAndSort(name string) func(samplesList ...[]prompb.Sample) []prompb.Sample {
 	return func(samplesList ...[]prompb.Sample) []prompb.Sample {
+		name = strings.ToLower(name)
+
 		var aggFunc func(i, j float64) float64
-		switch strings.ToLower(name) {
+		switch name {
 		case Min:
 			aggFunc = func(i, j float64) float64 {
 				if i < j {
@@ -87,15 +99,14 @@ func MergeSamplesWithFuncAndSort(name string) func(samplesList ...[]prompb.Sampl
 
 		for i, timestamp := range timestamps {
 			var value float64
-			switch name {
 			// Avg 方法需要等所有的数据合并了之后，再做计算
-			case Avg:
+			if isAvgFunc(name) {
 				if countMap[timestamp] > 0 {
 					value = sampleMap[timestamp] / countMap[timestamp]
 				} else {
 					value = 0
 				}
-			default:
+			} else {
 				value = sampleMap[timestamp]
 			}
 

--- a/pkg/unify-query/internal/function/samples_test.go
+++ b/pkg/unify-query/internal/function/samples_test.go
@@ -107,7 +107,13 @@ func TestMergeSamples(t *testing.T) {
 		},
 	}, t6)
 
-	t8 := MergeSamplesWithUnionAndSort(t1, t2)
+	t7 := MergeSamplesWithFuncAndSort(Mean)(t1, t2)
+	assert.Equal(t, t6, t7)
+
+	t8 := MergeSamplesWithFuncAndSort(AvgOT)(t1, t2)
+	assert.Equal(t, t6, t8)
+
+	t9 := MergeSamplesWithUnionAndSort(t1, t2)
 	assert.Equal(t, []prompb.Sample{
 		{
 			Timestamp: 1734462719000,
@@ -129,5 +135,5 @@ func TestMergeSamples(t *testing.T) {
 			Timestamp: 1734462839000,
 			Value:     5,
 		},
-	}, t8)
+	}, t9)
 }

--- a/pkg/unify-query/tsdb/prometheus/instance_test.go
+++ b/pkg/unify-query/tsdb/prometheus/instance_test.go
@@ -23,6 +23,7 @@ import (
 	promRemote "github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/internal/function"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/metadata"
 	"github.com/TencentBlueKing/bkmonitor-datalink/pkg/unify-query/mock"
 )
@@ -41,6 +42,28 @@ var _ storage.Queryable = (*queryable)(nil)
 
 func (q *queryable) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
 	return &querier{}, nil
+}
+
+func TestMergeFuncName(t *testing.T) {
+	assert.Equal(t, function.Max, mergeFuncName(&storage.SelectHints{Func: function.Max}, []*Query{
+		{
+			qry: &metadata.Query{
+				Aggregates: metadata.Aggregates{
+					{Name: function.Avg},
+				},
+			},
+		},
+	}))
+
+	assert.Equal(t, function.Avg, mergeFuncName(&storage.SelectHints{}, []*Query{
+		{
+			qry: &metadata.Query{
+				Aggregates: metadata.Aggregates{
+					{Name: function.Avg},
+				},
+			},
+		},
+	}))
 }
 
 type querier struct{}

--- a/pkg/unify-query/tsdb/prometheus/querier.go
+++ b/pkg/unify-query/tsdb/prometheus/querier.go
@@ -101,6 +101,22 @@ func (q *Querier) getQueryList(referenceName string) []*Query {
 	return queryList
 }
 
+func mergeFuncName(hints *storage.SelectHints, queryList []*Query) string {
+	if hints != nil && hints.Func != "" {
+		return hints.Func
+	}
+
+	for _, query := range queryList {
+		if query == nil || query.qry == nil {
+			continue
+		}
+		if name := query.qry.Aggregates.LastAggName(); name != "" {
+			return name
+		}
+	}
+	return ""
+}
+
 // selectFn 获取原始数据
 func (q *Querier) selectFn(hints *storage.SelectHints, matchers ...*labels.Matcher) storage.SeriesSet {
 	var (
@@ -127,20 +143,6 @@ func (q *Querier) selectFn(hints *storage.SelectHints, matchers ...*labels.Match
 
 	qp := metadata.GetQueryParams(ctx)
 
-	go func() {
-		defer func() {
-			recvDone <- struct{}{}
-		}()
-		var sets []storage.SeriesSet
-		for s := range setCh {
-			if s != nil {
-				sets = append(sets, s)
-			}
-		}
-
-		set = storage.NewMergeSeriesSet(sets, function.NewMergeSeriesSetWithFuncAndSort(hints.Func))
-	}()
-
 	for _, m := range matchers {
 		if m.Name == labels.MetricName {
 			referenceName = m.Value
@@ -152,6 +154,22 @@ func (q *Querier) selectFn(hints *storage.SelectHints, matchers ...*labels.Match
 	span.Set("reference_name", referenceName)
 
 	queryList := q.getQueryList(referenceName)
+	mergeFunc := mergeFuncName(hints, queryList)
+	span.Set("merge_func", mergeFunc)
+
+	go func() {
+		defer func() {
+			recvDone <- struct{}{}
+		}()
+		var sets []storage.SeriesSet
+		for s := range setCh {
+			if s != nil {
+				sets = append(sets, s)
+			}
+		}
+
+		set = storage.NewMergeSeriesSet(sets, function.NewMergeSeriesSetWithFuncAndSort(mergeFunc))
+	}()
 
 	p, _ := ants.NewPool(q.maxRouting)
 	defer p.Release()


### PR DESCRIPTION
## Summary

- handle avg/avg_over_time/mean when merging same-timestamp samples across route query results
- fall back to structured query aggregate name when SelectHints does not carry the merge function
- add coverage for avg route merge and mean/avg_over_time sample merge

## Root Cause

Route merge only handled min/max specially. Average-like functions fell through to the default sum behavior, so ES/Doris split route results could be added together instead of re-averaged by timestamp.

## Validation

```bash
rtk proxy /root/go/go1.25.5/bin/go test ./...
```

Run from `pkg/unify-query`; all packages passed.